### PR TITLE
Increase CMD[]  size to allow sending commands longer than 128 bytes

### DIFF
--- a/RUI/Source/driver/bg96.c
+++ b/RUI/Source/driver/bg96.c
@@ -337,7 +337,7 @@ int Gsm_CheckSimCmd(void)
 void Gsm_print(uint8_t *at_cmd)
 {
     uint8_t cmd_len;
-    uint8_t CMD[128] = {0};
+    uint8_t CMD[528] = {0};
     if(at_cmd == NULL)
         return;
     memset(CMD, 0, GSM_GENER_CMD_LEN);


### PR DESCRIPTION
I am trying to send a UDP packet with AT+QISENDEX .

When the string is bigger than 120 characters long, then I don't get any response from the modem, and the program hangs... The Quectel manual specifies that the string can be 512 bytes long.

CAUSE: the size of the at command buffer is 128 bytes. Sending an AT command bigger than this causes the program to hang